### PR TITLE
Have git-amb find tmpfs based build and install dirs

### DIFF
--- a/git-amb/git-amb.in
+++ b/git-amb/git-amb.in
@@ -157,6 +157,43 @@ cond_cat_path() {
     echo "$path"
 }
 
+# FIXME: We *COULD* detect `findmnt` and `sort -h` from
+#        `configure.ac`, but this appears to work as well.
+gnu_find_rootdir() {
+    if findmnt --version > /dev/null; then :; else
+	return 1
+    fi
+    if tmp1="$(printf "1.7G\n3.6K\n2.1M\n" | sort -h)"; then
+	tmp2="$(printf "3.6K\n2.1M\n1.7G\n")"
+	if test "x$tmp1" != "x$tmp2"; then
+	    return 1
+	fi
+    else
+	return 1
+    fi
+    findmnt --type tmpfs --notruncate --nofsroot --noheadings --list --output SIZE,TARGET | sort -hr | while read SIZE TARGET; do
+	case "$TARGET" in
+	    /dev/*|/var/*)
+		continue
+		;;
+	    ${HOME}/*|*/${UID}|*/${USER})
+		mkdir -p "$TARGET/git-amb" || continue
+		echo "moo" > "$TARGET/git-amb/.tmpfile-$$" || continue
+		rm -f "$TARGET/git-amb/.tmpfile-$$" || continue
+		echo "$TARGET/git-amb";
+		return 0
+		;;
+	    *)
+		mkdir -p "$TARGET/$USER/git-amb" || continue
+		echo "moo" > "$TARGET/$USER/git-amb/.tmpfile-$$" || continue
+		rm -f "$TARGET/$USER/git-amb/.tmpfile-$$" || continue
+		echo "$TARGET/$USER/git-amb"
+		return 0
+		;;
+	esac
+    done
+}
+
 amb_init() {
     clean_path
     setup_env
@@ -178,11 +215,26 @@ amb_init() {
     test "x$(git --git-dir="$GIT_DIR" rev-parse --is-inside-work-tree 2> /dev/null)" = "xtrue"
     top_srcdir="$(cd_to_toplevel && pwd)"
 
-    tmp="$(git --git-dir="$GIT_DIR" config amb.builddir)" || tmp="$GIT_DIR/amb/build"
+    amb_project_id="$(git --git-dir="$GIT_DIR" config amb.project-id)" || amb_project_id="PATH"
+    case "$amb_project_id" in
+	BASENAME)
+	    project_id="$(basename "$top_srcdir")"
+	    ;;
+	PATH)
+	    project_id="$(echo "$top_srcdir" | sed 's|/|_|g')"
+	    ;;
+	*)
+	    project_id="$amb_project_id"
+	    ;;
+    esac
+
+    amb_projrootdir="$(git --git-dir="$GIT_DIR" config amb.rootdir)/$project_id" || amb_projrootdir="$(gnu_find_rootdir)/$project_id" || amb_projrootdir="$GIT_DIR/amb"
+
+    tmp="$(git --git-dir="$GIT_DIR" config amb.builddir)" || tmp="${amb_projrootdir}/build"
     amb_builddir="$(cond_cat_path "${top_srcdir}" "$tmp")"
     top_builddir="$(cond_cat_path "${top_srcdir}" "$tmp" "${git_branch}")"
 
-    tmp="$(git --git-dir="$GIT_DIR" config amb.installdir)" || tmp="$GIT_DIR/amb/install"
+    tmp="$(git --git-dir="$GIT_DIR" config amb.installdir)" || tmp="${amb_projrootdir}/install"
     amb_installdir="$(cond_cat_path "${top_srcdir}" "$tmp")"
     top_installdir="$(cond_cat_path "${top_srcdir}" "$tmp" "$git_branch")"
 

--- a/git-amb/git-amb.man.in
+++ b/git-amb/git-amb.man.in
@@ -99,44 +99,90 @@ Use
 to get and set the config values.
 If a config value is not set,
 .B git amb
-uses a built\-in default, which is not documented. In order to determine
-what the respective directories are, always run the
+uses a built\-in default which may or may not be documented below.
+.SS Directories
+In order to determine which directories git-amb actually uses, always run the
 .B git amb
 commands
 .I builddir
 and
 .I installdir
 instead of reading the config values.
-.SS amb.builddir
-Location of build tree, relative to top checkout (source) dir, or absolute.
-The branch name (or SHA in case of detached HEAD) will be appended to it.
-.SS amb.installdir
-Location of installation, relative to top checkout (source) dir, or absolute.
-The branch name (or SHA in case of detached HEAD) will be appended to it.
-.SS amb.params.autoreconf
+.TP
+.B amb.builddir
+Location of build tree, relative to top checkout (source) dir, or absolute. If not set, use a default based on \fBamb.rootdir\fR or the implementation defined git-amb rootdir default. The branch name (or SHA in case of detached HEAD) will be appended to it.
+.TP
+.B amb.installdir
+Location of installation, relative to top checkout (source) dir, or absolute. If not set, use a default based on \fBamb.rootdir\fR or the implementation defined git-amb rootdir default. The branch name (or SHA in case of detached HEAD) will be appended to it.
+.TP
+.B amb.rootdir
+The directory to put the builddir \fIbuild\fR and the installdir \fIinstall\fR into if \fBamb.builddir\fR and/or \fBamb.installdir\fR have not been set explicitly. If \fBamb.rootdir\fR is not set, a reasonable default value will be used in a place like e.g. the largest user writable RAM filesystem, somewhere in $HOME, or somewhere in the project's top source directory.
+.TP
+.B amb.project-id
+If \fBamb.rootdir\fR has not been configured, \fBamb.project\-id\fR will supply a project ID to use when composing the default value for \fBamb.rootdir\fR. Valid values are
+.RS
+.TP
+.I BASENAME
+to use just the project basename (e.g. \fIndim-git-utils\fR if the project is in \fI/home/usr/src/ndim-git-utils\fR)
+.TP
+.I PATH
+to use a mangled path (e.g. \fI_home_user_src_ndim-git-utils\fR if the project is in \fI/home/user/src/ndim-git-utils\fR)
+.TP
+.I "other"
+to use the string \fIother\fR verbatim, regardless of directory name, path etc.
+.RE
+.SS Parameters To Build Commands
+.TP
+.B amb.params.autoreconf
 A few parameters to append to the
 .I autoreconf
 command line by default. Multiple values are possible. The default is empty.
-.SS amb.params.configure
+.TP
+.B amb.params.configure
 A few parameters to append to the
 .I configure
 command line by default. Multiple values are possible. The default is empty.
-.SS amb.params.make
+.TP
+.B amb.params.make
 A few parameters to append to the
 .I make
 command line by default. Multiple values are possible. The default is empty. Will substitute the string \fB`%NPROC%`\fR with the number of CPUs as printed by \fBnproc(1)\fR, which can be useful for the \fI-j\fR and \fI-l\fR make arguments.
-.SS amb.env.set
+.SS Build Command Environment
+.TP
+.B amb.env.set
 A few environment variables to set.
-.SS amb.env.unset
+.TP
+.B amb.env.unset
 A few environment variables to unset.
-.SS amb.path.exclude
+.TP
+.B amb.path.exclude
 A few path components to exclude from
 .B $PATH
-.SS amb.path.include
+.TP
+.B amb.path.include
 A few path components to add to
 .B PATH
 environment variable.
 .SH EXAMPLES
+Show build and install directories to use (Note: the exact paths might differ depending on a number of factors):
+.nf
+  $ git amb builddir; git amb installdir
+  /home/$USER/src/ndim-git-utils/_build/main
+  /home/$USER/src/ndim-git-utils/_install/main
+.fi
+or (if \fBamb.project-id\fR is \fIPATH\fR)
+.nf
+  $ git amb builddir; git amb installdir
+  /tmp/$USER/git-amb/_home_$USER_src_ndim-git-utils/build/main
+  /tmp/$USER/git-amb/_home_$USER_src_ndim-git-utils/install/main
+.fi
+or (if \fBamb.project-id\fR is \fIBASENAME\fR)
+.nf
+  $ git amb builddir; git amb installdir
+  /tmp/$USER/git-amb/ndim-git-utils/build/main
+  /tmp/$USER/git-amb/ndim-git-utils/install/main
+.fi
+.PP
 Define local build dirs, relative to top source tree dir.
 .nf
   $ git config amb.builddir _build


### PR DESCRIPTION
If `amb.rootdir` has not been set, `git-amb` will now determine a suitable `amb.rootdir` to put `builddir` and `installdir`. Candidates are `/tmp` like `tmpfs` RAM filesystems, `$HOME`, or the `top_srcdir`. To these, path components like `$USER`, `"git-amb"`, a `project-id` (`amb.project-id`, or project basename, or canonicalized project path), and then either `"build"` or `"install"` will be added.

TODO: Make sure the behaviour makes sense both in the default case and if `amb.rootdir` and/or `amb.builddir` and/or `amb.installdir` and/or `amb.project_id` has been configured.

The part about using `tmpfs` as the default build/install directory for this 15 year old tool `git-amb` has been inspired by https://twitter.com/LaF0rge/status/1539646879495032835:

[@LaF0rge](https://twitter.com/LaF0rge)
> the various embedded ARM/Linux boards (rpi, etc) all simply don't have enough RAM  to build reasonably complex software  from tmpfs.  And building from SD/SSD is slooow (and wears the flash out quickly).